### PR TITLE
Add alloc() method to INSObject

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -50,6 +50,14 @@ pub trait INSObject : Any + Sized + Message {
             Id::from_retained_ptr(obj)
         }
     }
+    
+    fn alloc() -> Id<Self> {
+        let cls = Self::class();
+        unsafe {
+            let obj: *mut Self = msg_send![cls, alloc];
+            Id::from_retained_ptr(obj)
+        }
+    }
 }
 
 object_struct!(NSObject);


### PR DESCRIPTION
Wrap `NSObject` `alloc()` method to allow allocation independent of initialization. This will allow me to do the equivalent of `[[NSWindow alloc] initWithContentRect ...]`in an AppKit wrapper.
