### PR TITLE
Link against gnustep-base on Linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,22 @@ pub use self::object::{INSObject, NSObject};
 pub use self::string::{INSCopying, INSMutableCopying, INSString, NSString};
 pub use self::value::{INSValue, NSValue};
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[link(name = "Foundation", kind = "framework")]
 extern { }
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+use objc::runtime::Class;
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[link(name = "gnustep-base", kind = "dylib")]
+extern { static _OBJC_CLASS_NSObject : Class; }
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[allow(dead_code)]
+unsafe fn get_class_to_force_linkage() -> &'static Class {
+    &_OBJC_CLASS_NSObject
+}
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Hi SSheldon!

Another small patch for supporting GNUstep-flavoured Objective-C interop on Linux. Pretty straightforward except for a small trick required to get the linker to behave as required. 

Unfortunately, it is dependent on the changes detailed in SSheldon/rust-block#2.

Cheers,

Niels
