### PR TITLE
Enable cargo doc/check on non-Darwin platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::object::{INSObject, NSObject};
 pub use self::string::{INSCopying, INSMutableCopying, INSString, NSString};
 pub use self::value::{INSValue, NSValue};
 
-#[link(name = "Foundation", kind = "framework")]
+#[cfg_attr(any(target_os = "macos", target_os = "ios"), link(name = "Foundation", kind = "framework"))]
 extern { }
 
 #[macro_use]


### PR DESCRIPTION
`cargo doc` fails on Linux, Windows, etc. because of the attempt to link with OS X/iOS frameworks. This adds a `target_os` check to prevent framework linking in these cases.