### PR TITLE
Basic version of NSError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/
 target/
 Cargo.lock
+.idea

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,27 @@
+use objc_id::Id;
+use {INSObject, NSInteger, NSDictionary, NSString, INSString};
+
+pub type NSErrorUserInfoKey = NSString;
+
+#[allow(non_snake_case)]
+pub fn NSLocalizedDescriptionKey() -> Id<NSString> {
+    NSString::from_str(&"NSLocalizedDescription")
+}
+
+pub trait INSError: INSObject {
+    fn new<T>(code: NSInteger, domain: Id<NSString>, user_info: Id<NSDictionary<NSErrorUserInfoKey, T>>) -> Id<Self> {
+        let cls = Self::class();
+        unsafe {
+            let obj: *mut Self = msg_send![cls, alloc];
+            let obj: *mut Self = msg_send![obj, initWithDomain:domain
+                                                          code:code
+                                                      userInfo:user_info];
+            Id::from_retained_ptr(obj)
+        }
+    }
+}
+
+object_struct!(NSError);
+
+impl INSError for NSError {}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ pub use self::array::{
 pub use self::data::{INSData, INSMutableData, NSData, NSMutableData};
 pub use self::dictionary::{INSDictionary, NSDictionary};
 pub use self::enumerator::{INSFastEnumeration, NSEnumerator, NSFastEnumerator};
+pub use self::error::{INSError, NSError, NSLocalizedDescriptionKey};
 pub use self::object::{INSObject, NSObject};
+pub use self::runtime::{NSInteger, NSUInteger};
 pub use self::string::{INSCopying, INSMutableCopying, INSString, NSString};
 pub use self::value::{INSValue, NSValue};
 
@@ -28,6 +30,8 @@ mod array;
 mod data;
 mod dictionary;
 mod enumerator;
+mod error;
 mod object;
+mod runtime;
 mod string;
 mod value;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,2 @@
+pub type NSInteger = isize;
+pub type NSUInteger = usize;


### PR DESCRIPTION
This is not a full PR, but I want to open it up to start talking about it. There are several things in here:

* Creates an NSError type (which is the piece I'm interested in)
* Creates a new constant ` NSLocalizedDescriptionKey()`, but this doesn't feel like a great way to define constants (could they be imported from ObjC directly? Could they be const rather than a function?)
* Creates NSInteger and NSUInteger in runtime.rs. This is a bit confusing, since there is already objc-runtime.

The objc2 repo doesn't seem ready for primetime. Is it better to extend this one or work there? Is there a better approach to all of this? My primary need is to call Rust code from Swift, and I'm looking for how to best do that. Currently I'm using this NSError as follows:

```
#[no_mangle]
pub extern "C" fn initThing(
    json: &NSData,
    error: *mut *const NSError,
) -> bool {
    if let Err(err) = init_thing(json.bytes()) {
        let value = NSString::from_str(&format!("{:?}", err));
        let user_info =
            NSDictionary::from_keys_and_objects(&[&*NSLocalizedDescriptionKey()], vec![value]);
        unsafe {
            let nserror = NSError::new(0, NSString::from_str("myDomain"), user_info);
            *error = &*nserror;
            mem::forget(nserror);
        }
        false
    } else {
        true
    }
}
```

I then consume it with this:

```
// This is a hack around the Swift/ObjC importer not handling top-level functions:
// https://bugs.swift.org/browse/SR-7400
func callRust<T>(_ f: (T, NSErrorPointer) -> Bool, _ p1: T) throws {
    var error: NSError? = nil
    if !f(p1, &error), let error = error {
        throw error
    }
}

class MyThing {
    init() {
        let json = getData()

        do {
            try callRust(initThing, json)
        } catch let error {
            print("FAILED: \(error)")
        }
    }
}
```

I don't think this is a fully baked approach (and it's very ugly), so I'm looking for direction.